### PR TITLE
fix bug where percentFilled does not update after learner assignment

### DIFF
--- a/functions/logStripeEvent.js
+++ b/functions/logStripeEvent.js
@@ -105,6 +105,7 @@ exports.handlePaymentIntentSucceeded = async (intent, id) => {
     }
     const uid = await helpers.getOrCreateDonor(params);
     params['sourceDonor'] = uid;
+    console.log(`user is ${uid}`);
     logDonation.writeDonation(params); // kick off the asynchronous write
     return {msg: 'successfully handled intent', data: {uid: uid}};
   } catch (err) {

--- a/functions/onDonationIncrease.js
+++ b/functions/onDonationIncrease.js
@@ -10,7 +10,9 @@ exports.onDonationIncrease = functions.firestore
     .onUpdate((change, context)=>{
       const before = change.before.data();
       const after = change.after.data();
-      if (before.amount !== after.amount || !after.percentFilled) {
+      if (before.amount !== after.amount || !after.percentFilled ||
+          before.learnerCount !== after.learnerCount ||
+          before.costPerLearner !== after.costPerLearner) {
         return this.updatePercentFilled(change.after, context);
       } else if (before.percentFilled < 100 && after.percentFilled >= 100) {
         helpers.sendEmail(after.sourceDonor, 'donationCompleted');


### PR DESCRIPTION
added checks to make sure a donation's `percentFilled` value updates whenever one of its dependent values is updated (`amount`, `learnerCount`, `costPerLearner`)
moved log statement after variable assignment