### PR TITLE
send update emails without sign in link

### DIFF
--- a/functions/config/email-options.json
+++ b/functions/config/email-options.json
@@ -3,18 +3,18 @@
 		"from": "followthelearners@curiouslearning.org",
 		"subject": "Follow the Learners -- Your Learners are Ready!",
 		"text": "Hi ${formattedName}, thank you for helping support Follow the Learners™! Click the link below, navigate to the \"Your Learners\" section, and enter your email to view how we're using your donation to bring reading into the lives of children!\n\n${url}\n\nIf you have any issues, please contact followthelearners@curiouslearning.org and we will be happy to assist you.\n\n~ Your Follow The Learners™ Team",
-		"utm_source": "?utm_source=donation_started"
+		"utm_source": "?utm_source=donation_started&referrer=update_email"
 	},
 	"halfwayMark": {
 		"from": "followthelearners@curiouslearning.org",
 		"subject": "Follow the Learners -- You've filled half your donation!",
 		"text": "Hi ${formattedName},  thank you for helping support Follow the Learners™! We've used half of your donation so far to help children access reading around the world! Click the link below and enter your email to view how we're using your donation to bring reading into the lives of children!\n\n${url}\n\nIf you have any issues, please contact followthelearners@curiouslearning.org and we will be happy to assist you.\n\n~ Your Follow The Learners™ Team",
-		"utm_source": "?utm_source=donation_halfway"
+		"utm_source": "?utm_source=donation_halfway&referrer=update_email"
 	},
 	"donationCompleted": {
 		"from": "followthelearners@curiouslearning.org",
 		"subject": "Follow the Learners -- Your Donation is Filled!",
 		"text": "Hi ${formattedName},\n Great news! All your donation has been put to work! Follow the link below to see all your learners.\n Once you’ve had a look at your new learners, please consider making another donation to bring reading into the lives of even more children.\n\n${url}\n\nIf you have any issues, please contact followthelearners@curiouslearning.org and we will be happy to assist you.\n\n~ Your Follow The Learners™ Team",
-		"utm_source": "?utm_source=donation_filled"
+		"utm_source": "?utm_source=donation_filled&referrer=update_email"
 	}
 }

--- a/functions/config/email-options.json
+++ b/functions/config/email-options.json
@@ -14,7 +14,7 @@
 	"donationCompleted": {
 		"from": "followthelearners@curiouslearning.org",
 		"subject": "Follow the Learners -- Your Donation is Filled!",
-		"text": "Hi ${formattedName},\n Great news! All your donation has been put to work! Follow the link below to see all your learners.\n Once you’ve had a look at your new learners, please consider making another donation to bring reading into the lives of even more children.\n\n${url}\n\nIf you have any issues, please contact followthelearners@curiouslearning.org and we will be happy to assist you.\n\n~ Your Follow The Learners™ Team",
+		"text": "Hi ${formattedName},\n Great news! All your donation has been put to work!\n\n${url}\n\nIf you are touched and inspired by the impact you see your dollars making on these children who are just now teaching themselves to read, please click a link below to tell us:\n\t- I would like to do more now: followthelearners.curiouslearning.org/donate\n\t- I wish to be reminded of the opportunity to sponsor more children in the future. https://curiouslearning.us14.list-manage.com/subscribe?u=e7fc6811b410d9e7d8d5704ad&id=4b508ae5f2\n\nIf you have any issues, please contact followthelearners@curiouslearning.org and we will be happy to assist you.\n\n~ Your Follow The Learners™ Team",
 		"utm_source": "?utm_source=donation_filled&referrer=update_email"
 	}
 }

--- a/functions/helpers/firebaseHelpers.js
+++ b/functions/helpers/firebaseHelpers.js
@@ -257,29 +257,29 @@ const sendEmail = async (uid, emailType) => {
     const email = data.email;
     const capitalized = firstName.charAt(0).toUpperCase();
     const formattedName = capitalized + firstName.slice(1);
-    return admin.auth().generateSignInWithEmailLink(email, actionCodeSettings)
-        .then((link)=>{
-          const textConfigOptions = {
-            url: link,
-            formattedName: formattedName,
-          };
-          emailText = customizeText(emailConfig.text, textConfigOptions);
-          const mailOptions = {
-            from: emailConfig.from,
-            to: email,
-            subject: emailConfig.subject,
-            text: emailText,
-          };
-          return transporter.sendMail(mailOptions, (error, info) => {
-            if (error) {
-              console.error(error);
-              return;
-            } else {
-              console.log('email sent: ' + info.response);
-              return;
-            }
-          });
-        });
+    const textConfigOptions = {
+      url: 'followthelearners.curiouslearning.org/',
+      formattedName: formattedName,
+    };
+    if (emailConfig.utm_source) {
+      textConfigOptions.url = textConfigOptions.url + emailConfig.utm_source;
+    }
+    emailText = customizeText(emailConfig.text, textConfigOptions);
+    const mailOptions = {
+      from: emailConfig.from,
+      to: email,
+      subject: emailConfig.subject,
+      text: emailText,
+    };
+    return transporter.sendMail(mailOptions, (error, info) => {
+      if (error) {
+        console.error(error);
+        return;
+      } else {
+        console.log('email sent: ' + info.response);
+        return;
+      }
+    });
   });
 };
 

--- a/functions/helpers/firebaseHelpers.js
+++ b/functions/helpers/firebaseHelpers.js
@@ -240,6 +240,12 @@ const updateMasterLearnerCount = (country) => {
 * @return{Promise} A promise that resolves if the email successfully sends
 */
 const sendEmail = async (uid, emailType) => {
+  if (!uid || uid === '') {
+    throw new Error('a uid is required to send an email');
+  }
+  if (!emailType || !emailOptions.hasOwnProperty(emailType)) {
+    throw new Error(`email type ${emailType} is invalid. A valid email template must be used.`);
+  }
   const usrRef = admin.firestore().collection('donor_master').doc(uid);
   const emailConfig = emailOptions[emailType];
   let url = 'https://followthelearners.curiouslearning.org/campaigns';
@@ -280,6 +286,8 @@ const sendEmail = async (uid, emailType) => {
         return;
       }
     });
+  }).catch((err) => {
+    console.error(err);
   });
 };
 

--- a/functions/logDonation.js
+++ b/functions/logDonation.js
@@ -48,7 +48,7 @@ exports.logDonation = functions.https.onRequest(async (req, res) =>{
     }
     const uid = await helpers.getOrCreateDonor(params.email);
     params.sourceDonor = uid;
-    this.writeDonation(params)
+    await this.writeDonation(params)
     const msg = {msg:'successfully handled payment', uid: uid};
     return res.status(200).send({msg: msg, data: event});
   } catch (err) {
@@ -69,6 +69,9 @@ exports.writeDonation = async function(params) {
     costPerLearner = DEFAULTCPL;
   } else {
     costPerLearner = await helpers.getCostPerLearner(params.campaignID);
+    if (!costPerLearner) {
+      costPerLearner = DEFAULTCPL;
+    }
   }
   const docRef = dbRef.doc(params.sourceDonor);
   params['learnerCount'] = 0;

--- a/functions/logStripeEvent.js
+++ b/functions/logStripeEvent.js
@@ -46,6 +46,8 @@ exports.logPaymentIntent = functions.https.onRequest(async (req, res) => {
         console.log(`successful payment for ${intent.amount}`);
         msg = await this.handlePaymentIntentSucceeded(intent, event.id);
         console.log(`msg: ${msg}`);
+      } else {
+        msg = {msg: 'this is not a FTL donation and will be ignored', data: {}};
       }
       break;
     default:

--- a/test/functions/logDonation.spec.js
+++ b/test/functions/logDonation.spec.js
@@ -211,32 +211,7 @@ describe('functions/logDonation', async () => {
       );
     });
   });
-  describe('functions/logDonation/sendNewLearnersEmail', async () => {
-    let displayName;
-    let email;
-    beforeEach(() => {
-      displayName= 'fake-firstName';
-      email= 'fake@email.biz';
-      sandbox.stub(auth, 'generateSignInWithEmailLink').resolves('fake-url');
-      sandbox.stub(myFunction, 'generateNewLearnersEmail').returns('email sent');
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
-
-    it('should throw an error if the email is missing', async () => {
-      email = '';
-      sandbox.spy(console, 'error');
-      await myFunction.sendNewLearnersEmail(displayName, email);
-      console.error.should.have.been.called;
-    });
-    it('should log an error if the link generation fails', async () => {
-      auth.generateSignInWithEmailLink.rejects('fake-error');
-      sandbox.spy(console, 'error');
-      await myFunction.sendNewLearnersEmail(displayName, email);
-      console.error.should.have.been.called;
-    });
-  });
+  
   describe('function/logDonation/createDonor', async () => {
     let params;
     let stubTime;

--- a/test/functions/logDonation.spec.js
+++ b/test/functions/logDonation.spec.js
@@ -27,6 +27,7 @@ describe('functions/logDonation', async () => {
     const firestore = admin.firestore.Firestore;
     let docStub;
     let writeStub;
+    let getOrCreateStub;
     let status;
     let send;
     let res;
@@ -49,6 +50,8 @@ describe('functions/logDonation', async () => {
           frequency: 'one-time',
         },
       };
+      getOrCreateStub = sandbox.stub(helpers, 'getOrCreateDonor');
+      getOrCreateStub.resolves('fake-donor');
       run = async () =>{
         const request = new PassThrough();
         const write = sandbox.stub(request, 'write');
@@ -72,6 +75,7 @@ describe('functions/logDonation', async () => {
         campaignID: 'fake-campaign',
         country: 'fake-country',
         referralSource: 'fake-referral',
+        sourceDonor: 'fake-donor',
       });
       res.status.should.have.been.calledWith(200);
     });
@@ -96,6 +100,7 @@ describe('functions/logDonation', async () => {
         country: 'MISSING',
         referralSource: 'MISSING',
         needsAttention: true,
+        sourceDonor: 'fake-donor',
       }));
     });
     it('should throw an error', async ()=> {
@@ -103,7 +108,7 @@ describe('functions/logDonation', async () => {
       writeStub.resolves();
       docStub.body = undefined;
       await run();
-      res.status.should.have.been.calledWith(501);
+      res.status.should.have.been.calledWith(400);
     });
   });
   // refactor to unit test new methods
@@ -124,6 +129,7 @@ describe('functions/logDonation', async () => {
         frequency: 'one-time',
         timestamp: stubTime,
         stripeEventId: 'fake-event',
+        sourceDonor: 'fake-donor',
       };
       fakeUser = {
         uid: 'fake-donor',
@@ -135,14 +141,13 @@ describe('functions/logDonation', async () => {
       sandbox.stub(auth, 'createUser').resolves(fakeUser);
       sandbox.stub(firestore.DocumentReference.prototype, 'set').resolves();
       sandbox.stub(firestore.DocumentReference.prototype, 'update').resolves();
+      sandbox.stub(helpers, 'sendEmail');
       sandbox.stub(firestore.CollectionReference.prototype, 'add').resolves({
         id: 'fake-donation',
         update: () =>{return sinon.stub().resolves()},
       });
       sandbox.stub(helpers, 'getCostPerLearner').returns(0.25);
       sandbox.stub(assignLearners, 'assign').resolves();
-      sandbox.stub(auth, 'generateSignInWithEmailLink').resolves('fake-url');
-      sandbox.stub(myFunction, 'generateNewLearnersEmail').resolves();
     });
     afterEach(() => {
       sandbox.restore();
@@ -155,35 +160,23 @@ describe('functions/logDonation', async () => {
           params.country,
       );
     });
-    it('should call createUser with the correct params', async () => {
-      await myFunction.writeDonation(params);
-      auth.createUser.should.have.been.calledWith({
-        displayName: 'fake-firstName',
-        email: 'fake@email.biz',
-      });
-    });
-    it('should call set with the correct params', async () => {
-      await myFunction.writeDonation(params);
-      firestore.DocumentReference.prototype.set.should.have.been.calledWith({
-        firstName: 'fake-firstName',
-        email: 'fake@email.biz',
-        dateCreated: stubTime,
-        donorID: 'fake-donor',
-      });
-    });
     it('should call add with the correct params', async () => {
       await myFunction.writeDonation(params);
       firestore.CollectionReference.prototype.add.should.have.been.calledWith({
-        campaignID: 'fake-campaign',
+        campaignID: params.campaignID,
+        email: params.email,
+        firstName: params.firstName,
         learnerCount: 0,
-        sourceDonor: 'fake-donor',
+        referralSource: params.referralSource,
+        sourceDonor: params.sourceDonor,
         amount: 5,
-        stripeEventId: 'fake-event',
+        stripeEventId: params.stripeEventId,
         costPerLearner: 0.25,
-        frequency: 'one-time',
+        frequency: params.frequency,
         countries: [],
         startDate: stubTime,
-        country: 'fake-country',
+        country: params.country,
+        timestamp: params.timestamp,
       });
     });
     it('should throw an error on a missing donor', async ()=> {
@@ -192,116 +185,33 @@ describe('functions/logDonation', async () => {
       await myFunction.writeDonation(params);
       console.error.should.have.been.calledWith('No email was provided to identify or create a user!');
     });
-    it('should throw an error on a missing costPerLearner', async () => {
-      helpers.costPerLearner = sandbox.stub().resolves(undefined);
+    it('should use the default cpl on a missing costPerLearner', async () => {
+      helpers.getCostPerLearner = sandbox.stub().resolves(undefined);
       sandbox.spy(myFunction, 'writeDonation');
-      try {
-        await myFunction.writeDonation(params);
-      } catch (e) {
-        e.message.should.equal('received undefined cost per learner');
-      }
-      myFunction.writeDonation.should.have.thrown;
+      await myFunction.writeDonation(params);
+      firestore.CollectionReference.prototype.add.should.have.been.calledWith({
+        campaignID: params.campaignID,
+        email: params.email,
+        firstName: params.firstName,
+        learnerCount: 0,
+        referralSource: params.referralSource,
+        sourceDonor: params.sourceDonor,
+        amount: 5,
+        stripeEventId: params.stripeEventId,
+        costPerLearner: 1,
+        frequency: params.frequency,
+        countries: [],
+        startDate: stubTime,
+        country: params.country,
+        timestamp: params.timestamp,
+      })
     });
     it('should call sendNewLearnersEmail with the correct params', async () => {
       await myFunction.writeDonation(params);
-      myFunction.generateNewLearnersEmail.should.have.been.calledWith(
-          'fake-firstName',
-          'fake@email.biz',
-          'fake-url',
+      helpers.sendEmail.should.have.been.calledWith(
+          'fake-donor',
+          'donationStart',
       );
-    });
-  });
-  
-  describe('function/logDonation/createDonor', async () => {
-    let params;
-    let stubTime;
-    let fakeUser;
-    beforeEach(() => {
-      stubTime = firestore.Timestamp.now();
-      params = {
-        firstName: 'fake-firstName',
-        email: 'fake@email.biz',
-        amount: 5,
-        campaignID: 'fake-campaign',
-        country: 'fake-country',
-        referralSource: 'fake-referral',
-        frequency: 'one-time',
-        timestamp: stubTime,
-      };
-      fakeUser = {
-        uid: 'fake-donor',
-        displayName: 'fake-firstName',
-        email: 'fake@email.biz',
-      };
-      sandbox.stub(firestore.Timestamp, 'now').returns(stubTime);
-      sandbox.stub(auth, 'createUser').resolves(fakeUser);
-      sandbox.stub(firestore.DocumentReference.prototype, 'set').resolves();
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
-
-    it('should add a needs attention flag with missing data', async () => {
-      params.referralSource = 'MISSING';
-      params['needsAttention'] = true;
-      await myFunction.createDonor(params);
-      firestore.DocumentReference.prototype.set.should.have.been.calledWith({
-        firstName: 'fake-firstName',
-        email: 'fake@email.biz',
-        dateCreated: stubTime,
-        donorID: 'fake-donor',
-        needsAttention: true,
-      });
-    });
-    it('should log an error if it cannot create a user', async () => {
-      auth.createUser.rejects('failure');
-      sandbox.spy(console, 'error');
-      await myFunction.createDonor(params);
-      console.error.should.have.been.called;
-    });
-  });
-  describe('functions/logDonation/generateNewLearnersEmail', async () => {
-    let name;
-    let email;
-    let url;
-    let sendMail;
-    let transport;
-    let mailer;
-    beforeEach(() => {
-      name = 'fake-firstName';
-      email = 'fake@email.biz';
-      url = 'fake-url';
-      transport = {
-        sendMail: (data, callback) => {
-          callback(null, {response: 'okay'});
-        },
-      };
-      sendMail = sandbox.stub(nodemailer, 'createTransport');
-      sendMail.returns(transport);
-      mailer = sandbox.stub(Mailer.prototype, 'sendMail');
-      mailer.callsArgWith(1, null, 'success');
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
-
-    it('should call the callback', async () => {
-      sandbox.spy(console, 'log');
-      await myFunction.generateNewLearnersEmail(name, email, url);
-      console.log.should.have.been.called;
-    });
-    it('should log an error', async () => {
-      sandbox.spy(console, 'error');
-      transport = {
-        sendMail: (data, callback) => {
-          const err = new Error('you failed');
-          callback(err, null);
-        },
-      };
-      sendMail.returns(transport);
-      // mailer.callsArgWith(1, new Error(), null);
-      await myFunction.generateNewLearnersEmail(name, email, url);
-      console.error.should.have.been.called;
     });
   });
 });

--- a/test/functions/onDonationIncrease.spec.js
+++ b/test/functions/onDonationIncrease.spec.js
@@ -34,6 +34,7 @@ describe('functions/onDonationIncrease', async () => {
           campaignID: 'fake-campaign',
           sourceDonor: 'fake-donor',
           learnerCount: 20,
+          costPerLearner: 0.25,
           endDate: admin.firestore.Firestore.Timestamp.now(),
         };
       },
@@ -47,6 +48,7 @@ describe('functions/onDonationIncrease', async () => {
           campaignID: 'fake-campaign',
           sourceDonor: 'fake-donor',
           learnerCount: 20,
+          costPerLearner: 0.25,
           endDate: admin.firestore.Firestore.Timestamp.now(),
         };
       },
@@ -104,6 +106,8 @@ describe('functions/onDonationIncrease', async () => {
         return {
           amount: 5,
           percentFilled: 100,
+          costPerLearner: 0.25,
+          learnerCount: 20,
         };
       },
     };


### PR DESCRIPTION
- change email link sent in update emails to a simple url + utm tags, instead of temporary sign in link with implicit expirations
- include `referrer=email_update` tag to be handled by browser 