### PR TITLE
Update account email

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,20 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    }
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -28,6 +28,8 @@ exports.forceRegionRecalculation = forceRegion.forceRegionRecalculation;
 const stripeHooks = require('./logStripeEvent');
 exports.logPaymentIntent= stripeHooks.logPaymentIntent;
 exports.testPaymentIntent= stripeHooks.testPaymentIntent;
+const updateAccountEmail = require('./updateAccountEmail');
+exports.updateAccountEmail = updateAccountEmail.updateAccountEmail;
 if (admin.apps.length === 0) {
   admin.initializeApp();
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,7 +29,7 @@ const stripeHooks = require('./logStripeEvent');
 exports.logPaymentIntent= stripeHooks.logPaymentIntent;
 exports.testPaymentIntent= stripeHooks.testPaymentIntent;
 const updateAccountEmail = require('./updateAccountEmail');
-exports.updateAccountEmail = updateAccountEmail.updateAccountEmail;
+exports.forceUpdateAccountEmail = updateAccountEmail.forceUpdateAccountEmail;
 if (admin.apps.length === 0) {
   admin.initializeApp();
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1819,6 +1819,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2055,6 +2065,12 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -2261,6 +2277,15 @@
         }
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2449,6 +2474,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2481,6 +2515,12 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "optional": true
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -2675,9 +2715,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -3116,10 +3156,10 @@
         }
       }
     },
-    "mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
     "ms": {
@@ -3315,6 +3355,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -3390,6 +3436,17 @@
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "psl": {
@@ -3542,6 +3599,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,17 +19,18 @@
     "cors": "^2.8.5",
     "firebase-admin": "^9.3.0",
     "firebase-functions": "^3.11.0",
+    "lodash": "^4.17.20",
     "nodemailer": "^6.4.14"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^1.0.9",
-    "mockery": "^2.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.12.0",
     "eslint-plugin-promise": "^4.0.1",
     "firebase-functions-test": "^0.2.3",
     "mocha": "^8.2.1",
+    "proxyquire": "^2.1.3",
     "sinon": "^9.2.1",
     "sinon-chai": "^3.5.0"
   },

--- a/functions/updateAccountEmail.js
+++ b/functions/updateAccountEmail.js
@@ -7,7 +7,14 @@ if (admin.apps.length === 0) {
 const auth = admin.auth();
 const firestore = admin.firestore();
 
-exports.updateAccountEmail = functions.https.onRequest(async (req, res) => {
+/* Force Update a user's primary account
+* WARNING: This will delete the user in the authentication database,
+* creating a new user with the new email address and the same unique identifier.
+* Any authentication history (date created, last login, email verified, etc.)
+* will be lost. This should only be used if the user was initialized with an
+* invalid email address or is otherwise locked out of their account.
+*/
+exports.forceUpdateAccountEmail = functions.https.onRequest(async (req, res)=> {
   if (!req.body) {
     return res.status(400).send('no data provided!');
   }
@@ -17,7 +24,7 @@ exports.updateAccountEmail = functions.https.onRequest(async (req, res) => {
   } else if (!params.newEmail) {
     return res.status(400).send('parameter "newEmail" is required');
   }
-  await auth.getUserByEmail(params.currentEmail).then((user) => {
+  return auth.getUserByEmail(params.currentEmail).then((user) => {
     const uid = user.uid;
     return auth.deleteUser(uid).then(() => {
       const updateDoc = firestore.collection('donor_master').doc(uid)

--- a/functions/updateAccountEmail.js
+++ b/functions/updateAccountEmail.js
@@ -1,0 +1,58 @@
+const https= require('https');
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
+const auth = admin.auth();
+const firestore = admin.firestore();
+
+exports.updateAccountEmail = functions.https.onRequest(async (req, res) => {
+  if (!req.body) {
+    return res.status(400).send('no data provided!');
+  }
+  const params = req.body;
+  if (!params.currentEmail) {
+    return res.status(400).send('parameter "currentEmail" is required');
+  } else if (!params.newEmail) {
+    return res.status(400).send('parameter "newEmail" is required');
+  }
+  await auth.getUserByEmail(params.currentEmail).then((user) => {
+    const uid = user.uid;
+    return auth.deleteUser(uid).then(() => {
+      const updateDoc = firestore.collection('donor_master').doc(uid)
+          .get().then((doc)=>{
+            if (!doc.exists) {
+              //throw error
+              return;
+            }
+            return doc.update({email: params.newEmail});
+          });
+      const updateAuth = auth.createUser({
+        uid: uid,
+        email: params.newEmail,
+      });
+      return Promise.all([updateDoc, updateAuth]).then((vals)=>{
+        return res.status(200)
+            .send(`updated ${uid} with email: ${params.newEmail}`);
+      }).catch((err) => {
+        return res.status(500).send({
+          msg: `could not update ${uid} with email: ${email}.`,
+          err: err,
+        });
+      });
+    });
+  }).catch((err) => {
+    console.error(err);
+    switch (err.code) {
+      case 'auth/invalid-email':
+        return res.status(400)
+            .send(`could not find user with email: ${params.currentEmail}`);
+      default:
+        return res.status(500)
+          .send({msg: `could not update user with email ${params.currentEmail}`,
+            err: err
+          });
+    }
+  });
+});

--- a/test/functions/updateAccountEmail.spec.js
+++ b/test/functions/updateAccountEmail.spec.js
@@ -12,9 +12,8 @@ let stubTime;
 let timeStub;
 let Timestamp;
 let DocumentReference;
-let Query;
 
-describe('functions/updateAccountEmail', () => {
+describe('functions/forceUpdateAccountEmail', () => {
   const myFunction = proxyquire('../../functions/updateAccountEmail', {
     'firebase-admin': stubbedAdmin,
   });
@@ -60,7 +59,7 @@ describe('functions/updateAccountEmail', () => {
       const request = new PassThrough();
       sandbox.stub(request, 'write');
       this.request.returns(request);
-      return await myFunction.updateAccountEmail({body}, res);
+      return await myFunction.forceUpdateAccountEmail({body}, res);
     };
   });
   afterEach(() => {

--- a/test/functions/updateAccountEmail.spec.js
+++ b/test/functions/updateAccountEmail.spec.js
@@ -1,0 +1,116 @@
+
+const https = require('https');
+const functions = require('firebase-functions');
+const sinon = require('sinon');
+const admin = require('firebase-admin');
+const proxyquire = require('proxyquire');
+const cloneDeep = require('lodash/cloneDeep');
+const PassThrough = require('stream').PassThrough;
+const stubbedAdmin = cloneDeep(admin);
+const stubbedFunctions = cloneDeep(functions);
+let stubTime;
+let timeStub;
+let Timestamp;
+let DocumentReference;
+let Query;
+
+describe('functions/updateAccountEmail', () => {
+  const myFunction = proxyquire('../../functions/updateAccountEmail', {
+    'firebase-admin': stubbedAdmin,
+  });
+  const sandbox = sinon.createSandbox();
+  let currentEmail;
+  let newEmail;
+  let uid;
+  let body;
+  let run;
+  let res;
+  let status;
+  let send;
+  let findStub;
+  let deleteStub;
+  let createStub;
+  let getStub;
+  let docRef;
+  beforeEach(() => {
+    Timestamp = admin.firestore.Firestore.Timestamp;
+    DocumentReference = admin.firestore.Firestore.DocumentReference;
+    stubTime = Timestamp.now();
+    timeStub = sandbox.stub(Timestamp, 'now').returns(stubTime);
+    currentEmail = 'bad@email.biz';
+    newEmail = 'fake@email.biz';
+    uid = 'fake-user';
+    body = {newEmail, currentEmail};
+    docRef = {
+      exists: true,
+      update: sandbox.stub().resolves(),
+    };
+    findStub = sandbox.stub(stubbedAdmin.auth(), 'getUserByEmail');
+    findStub.resolves({uid});
+    deleteStub = sandbox.stub(stubbedAdmin.auth(), 'deleteUser').resolves();
+    createStub = sandbox.stub(stubbedAdmin.auth(), 'createUser');
+    createStub.resolves({uid: uid, email: newEmail});
+    getStub = sandbox.stub(DocumentReference.prototype, 'get').resolves(docRef);
+    status = sandbox.stub();
+    send = sandbox.spy();
+    res = {status, send};
+    status.returns(res);
+    this.request = sandbox.stub(https, 'request');
+    run = async () => {
+      const request = new PassThrough();
+      sandbox.stub(request, 'write');
+      this.request.returns(request);
+      return await myFunction.updateAccountEmail({body}, res);
+    };
+  });
+  afterEach(() => {
+    sandbox.restore();
+    timeStub.restore();
+  });
+  it('should call status with 200', async () => {
+    await run();
+    res.status.should.have.been.calledWith(200);
+  });
+  it('should fetch the correct user', async () => {
+    await run();
+    findStub.should.have.been.calledWith(currentEmail);
+  });
+  it('should call delete user with the uid', async () => {
+    await run();
+    deleteStub.should.have.been.calledWith(uid);
+  });
+  it('should call createUser with the expected params', async () => {
+    await run();
+    createStub.should.have.been.calledWith({uid, email: newEmail});
+  });
+  it('should call status with 400', async () => {
+    body.newEmail = undefined;
+    await run();
+    res.status.should.have.been.calledWith(400);
+  });
+  it('should call status with 400', async () => {
+    body.currentEmail = undefined;
+    await run();
+    res.status.should.have.been.calledWith(400);
+  });
+  it('should call status with 400', async () => {
+    findStub.rejects({code: 'auth/invalid-email'});
+    await run();
+    res.status.should.have.been.calledWith(400);
+  });
+  it('should call status with 500', async () => {
+    findStub.rejects('fake-error');
+    await run();
+    res.status.should.have.been.calledWith(500);
+  });
+  it('should call status with 500', async () => {
+    deleteStub.rejects();
+    await run();
+    res.status.should.have.been.calledWith(500);
+  });
+  it('should call status with 500', async () => {
+    createStub.rejects();
+    await run();
+    res.status.should.have.been.calledWith(500);
+  });
+});


### PR DESCRIPTION
Added an endpoint to change the primary email of the user while preserving account data and without requiring user authentication.
**Warning**: This will delete the user in the authentication database, creating a new user with the new email address and the _same_ unique identifier. Any authentication history (date created, last login, email verified, etc.) will be lost. This should only be used if the user was initialized with an invalid email address or is otherwise locked out of their account.